### PR TITLE
 add ExperimentHub to biocViews in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,5 +11,6 @@ Depends: SingleCellExperiment, HDF5Array
 Imports: AnnotationHub, ExperimentHub
 Suggests: knitr, BiocStyle, snow, BiocFileCache, BiocParallel
 VignetteBuilder: knitr
-biocViews: SequencingData, RNASeqData, ExpressionData, SingleCellData
+biocViews: SequencingData, RNASeqData, ExpressionData, ExperimentHub,
+    ExperimentData, SingleCellData
 NeedsCompilation: no


### PR DESCRIPTION
ExperimentHub needs to be added to biocViews list in DESCRIPTION file in order to validate metadata.